### PR TITLE
Update reading file to non-blocking

### DIFF
--- a/pages/blog/index.tsx
+++ b/pages/blog/index.tsx
@@ -32,20 +32,29 @@ Blog.defaultProps = {
   posts: [],
 }
 
-export function getStaticProps(ctx) {
+export async function getStaticProps(ctx) {
   const cmsPosts = (ctx.preview ? postsFromCMS.draft : postsFromCMS.published).map((post) => {
     const { data } = matter(post)
     return data
   })
 
   const postsPath = path.join(process.cwd(), 'posts')
-  const filenames = fs.readdirSync(postsPath)
-  const filePosts = filenames.map((name) => {
-    const fullPath = path.join(process.cwd(), 'posts', name)
-    const file = fs.readFileSync(fullPath, 'utf-8')
+  const filenames = await fs.promises.readdir(postsPath)
+  
+  const filePosts = await Promise.all(filenames.map(async (name) => {
+    /** get file fullpath with  */
+    const fullPath = path.join(process.cwd(), "posts", name)
+
+    /** read file content  */
+    const file = await fs.promises.readFile(fullPath, 'utf-8')
+
+    /** convert data to an object with matter lib */
     const { data } = matter(file)
+
+    /** return the data */
     return data
-  })
+  }))
+  
 
   const posts = [...cmsPosts, ...filePosts]
 


### PR DESCRIPTION
With fs.promises.readFile() method it is possible to use async/await and mostly important: it reads a file in a non-blocking asynchronous way and mostly important: it is not blocking the node event loop. This is crucial for production and nodejs application. A better solution would be using streams.

The downside in using fs.readFileSync() method, is that we are reading files in a synchronous fashion, this will block node.js event loop and will block other process, only after this syncronous method is finished,  all the remamining node program will be executed.

This PR is just a dropin replacement for the methods and everything will works the same way as before :)